### PR TITLE
Link vagrant files instead of checking them out if DEVELOPMENT=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ In order to use a cluster with HPCCloud the following requirements need to be av
 
 
 ### Local Development Installation
-if [HPCCloud](https://github.com/Kitware/HPCCloud), [girder](https://github.com/girder/girder), or [cumulus](https://github.com/Kitware/cumulus) are available in the folder above the cumulus-deploy checkout and the environment variable ```DEVELOPMENT``` is set to 1,  then these folders will be linked through the VM rather than checked out from github.  E.g.  with the directory structure:
+if [HPCCloud](https://github.com/Kitware/HPCCloud), [girder](https://github.com/girder/girder), or [cumulus](https://github.com/Kitware/cumulus) are available in the folder above the HPCCloud-deploy checkout and the environment variable ```DEVELOPMENT``` is set to 1,  then these folders will be linked through the VM rather than checked out from github.  E.g.  with the directory structure:
 
 ```
-./cumulus-deploy/
-                 Vagrantfile
-                 ansible/
-                 ...
+./HPCCloud-deploy/
+                  Vagrantfile
+                  ansible/
+                  ...
 ./cumulus/
           ...
 ./hpccloud/
@@ -92,4 +92,4 @@ if [HPCCloud](https://github.com/Kitware/HPCCloud), [girder](https://github.com/
          ...
 ```
 
-running ```DEVELOPMENT=1 vagrant up``` from within the ```cumulus-deploy/``` folder will link cumulus, hpccloud and girder folders.  This should allow those folders to be changed locally,  and for those changes to be picked up on restart from within the VM. Note:  if a folder is not available it will be checkout from github.  the HPCCloud folder must be lowercase!
+running ```DEVELOPMENT=1 vagrant up``` from within the ```HPCCloud-deploy/``` folder will link cumulus, hpccloud and girder folders.  This should allow those folders to be changed locally,  and for those changes to be picked up on restart from within the VM. Note:  if a folder is not available it will be checkout from github.  the HPCCloud folder must be lowercase!

--- a/README.md
+++ b/README.md
@@ -74,3 +74,22 @@ In order to use a cluster with HPCCloud the following requirements need to be av
  The `requirements-cluster.txt` can be found at the [root of this repository](https://github.com/Kitware/HPCCloud-deploy/blob/master/requirements-cluster.txt). These python package need to be available in the pvpython environment. If you have built ParaView against system python then the previous command will have ensured this. If you are using a prebuilt release then this [script](https://github.com/Kitware/HPCCloud-deploy/blob/master/pvpython_setup.sh) will install the required packages in the pvpython environment.
 
          ./pvpython_setup.sh <full path to pvpython executable>
+
+
+### Local Development Installation
+if [HPCCloud](https://github.com/Kitware/HPCCloud), [girder](https://github.com/girder/girder), or [cumulus](https://github.com/Kitware/cumulus) are available in the folder above the cumulus-deploy checkout and the environment variable ```DEVELOPMENT``` is set to 1,  then these folders will be linked through the VM rather than checked out from github.  E.g.  with the directory structure:
+
+```
+./cumulus-deploy/
+                 Vagrantfile
+                 ansible/
+                 ...
+./cumulus/
+          ...
+./hpccloud/
+           ...
+./girder/
+         ...
+```
+
+running ```DEVELOPMENT=1 vagrant up``` from within the ```cumulus-deploy/``` folder will link cumulus, hpccloud and girder folders.  This should allow those folders to be changed locally,  and for those changes to be picked up on restart from within the VM. Note:  if a folder is not available it will be checkout from github.  the HPCCloud folder must be lowercase!

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(2) do |config|
   if dev
     for f in ["cumulus", "hpccloud", "girder"]
       if File.directory?("../" + f)
-        config.vm.synced_folder "../#{f}", "/opt/hpccloud/#{f}",
+        config.vm.synced_folder "../#{f}", "/opt/hpccloud/" + f.downcase,
                                 owner: 1002, group: 1003
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,14 +24,19 @@ Vagrant.configure(2) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Note:  not currently possible to set ower/group of these files
+  # after provisioning (See: https://github.com/mitchellh/vagrant/issues/936)
+  # This means we need to set user and owner to UID/GUID which get created
+  # later (when we make the hpccloud and celery users)
   if dev
     for f in ["cumulus", "hpccloud", "girder"]
       if File.directory?("../" + f)
-        config.vm.synced_folder "../#{f}", "/opt/hpccloud/#{f}"
+        config.vm.synced_folder "../#{f}", "/opt/hpccloud/#{f}",
+                                owner: 1002, group: 1003
       end
     end
   end
-
 
   config.vm.define "hpccloud" do |node|
   end
@@ -82,6 +87,7 @@ Vagrant.configure(2) do |config|
     }
 
     ansible.playbook = "ansible/site.yml"
+
 
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@
 # you're doing.
 Vagrant.configure(2) do |config|
 
+  dev = if ENV['DEVELOPMENT'] then true else  false end;
 
   config.vm.box = "ubuntu/trusty64"
 
@@ -23,6 +24,14 @@ Vagrant.configure(2) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  if dev
+    for f in ["cumulus", "hpccloud", "girder"]
+      if File.directory?("../" + f)
+        config.vm.synced_folder "../#{f}", "/opt/hpccloud/#{f}"
+      end
+    end
+  end
+
 
   config.vm.define "hpccloud" do |node|
   end
@@ -68,8 +77,10 @@ Vagrant.configure(2) do |config|
     }
     ansible.verbose = "vv"
     ansible.extra_vars = {
-      default_user: "vagrant"
+      default_user: "vagrant",
+      development: dev
     }
+
     ansible.playbook = "ansible/site.yml"
 
   end

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -1,6 +1,11 @@
+- name: probe cumulus folder
+  stat: path=/opt/hpccloud/cumulus
+  register: path
+
 - name: Get cumulus from github
   git: repo=https://github.com/Kitware/cumulus.git version={{ cumulus_version }} dest=/opt/hpccloud/cumulus force=yes accept_hostkey=yes
   sudo: yes
+  when: path.stat.exists == False
   tags: cumulus
 
 - name: Install specified python requirements.

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -24,7 +24,7 @@
   tags: cumulus
 
 - name: Tell git to ignore permission changes
-  command: git config core.filemode false chdir=/opt/hpccloud/cumulus
+  command: git config --replace-all core.filemode false chdir=/opt/hpccloud/cumulus
   tags: cumulus
 
 - name: Get AMIs from EC2

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -48,9 +48,14 @@
   sudo: yes
   tags: girder
 
+- name: probe hpccloud folder
+  stat: path=/opt/hpccloud/girder
+  register: path
+
 - name: Get Girder from github
   git: repo=https://github.com/girder/girder.git version={{ girder_version }} dest=/opt/hpccloud/girder force=yes accept_hostkey=yes
   sudo: yes
+  when: path.stat.exists == False
   tags: girder
 
 - name: Change owner of girder directory

--- a/ansible/roles/hpccloud/tasks/main.yml
+++ b/ansible/roles/hpccloud/tasks/main.yml
@@ -1,7 +1,13 @@
+- name: probe hpccloud folder
+  stat: path=/opt/hpccloud/hpccloud
+  register: path
+
 - name: Get hpccloud from github
   git: repo=https://github.com/Kitware/HPCCloud.git version={{ hpccloud_version }} dest=/opt/hpccloud/hpccloud force=yes accept_hostkey=yes
   sudo: yes
+  when: path.stat.exists == False
   tags: hpccloud
+
 
 - name: Make sure we have the right version of npm
   npm: name=npm version=2.1.5 global=yes

--- a/ansible/roles/users/tasks/main.yml
+++ b/ansible/roles/users/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Create hpccloud user
-  user: name=hpccloud shell=/bin/bash
+  user: name=hpccloud shell=/bin/bash uid=1002
   tags: users
   sudo: yes
 


### PR DESCRIPTION
if [HPCCloud](https://github.com/Kitware/HPCCloud), [girder](https://github.com/girder/girder), or [cumulus](https://github.com/Kitware/cumulus) are available in the folder above the HPCCloud-deploy checkout and the environment variable `DEVELOPMENT` is set to 1,  then these folders will be linked through the VM rather than checked out from github.  E.g.  with the directory structure:

```
./HPCCloud-deploy/
                 Vagrantfile
                 ansible/
                 ...
./cumulus/
          ...
./hpccloud/
           ...
./girder/
         ...
```

running `DEVELOPMENT=1 vagrant up` from within the `HPCCloud-deploy/` folder will link cumulus, hpccloud and girder folders.  This should allow those folders to be changed locally,  and for those changes to be picked up on restart from within the VM. **Note:**  if a folder is not available it will be checkout from github.  the HPCCloud folder must be lowercase!
