### PR TITLE
Changes to support cumulus setuptools refactor

### DIFF
--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: probe cumulus folder
   stat: path=/opt/hpccloud/cumulus
   register: path
+  tags: cumulus
 
 - name: Get cumulus from github
   git: repo=https://github.com/Kitware/cumulus.git version={{ cumulus_version }} dest=/opt/hpccloud/cumulus force=yes accept_hostkey=yes
@@ -8,7 +9,7 @@
   when: path.stat.exists == False
   tags: cumulus
 
-- name: Install specified python requirements.
+- name: Install cumulus dependencies
   pip: requirements=/opt/hpccloud/cumulus/requirements.txt
   sudo: yes
   tags: cumulus
@@ -58,8 +59,26 @@
     - update_ips
 
 - name: Create config.json
-  action: template src=config.json.j2 dest=/opt/hpccloud/cumulus/config.json mode=640 owner=hpccloud group=celery
+  action: template src=config.json.j2 dest=/opt/hpccloud/cumulus/cumulus/conf/config.json mode=640 owner=hpccloud group=celery
   tags:
     - cumulus
     - update_ips
   sudo: yes
+
+- name: Install cumulus
+  pip:
+    chdir: /opt/hpccloud/cumulus
+    name: .
+    extra_args: "--user"
+  become_user: hpccloud
+  when: development == False
+  tags: cumulus
+
+- name: Install cumulus (Development)
+  pip:
+    chdir: /opt/hpccloud/cumulus
+    name: .
+    extra_args: "-e"
+  sudo: true
+  when: development == True
+  tags: cumulus

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -80,5 +80,5 @@
     name: .
     extra_args: "-e"
   sudo: true
-  when: development == True
+  when: development
   tags: cumulus

--- a/ansible/roles/girder/files/girder.conf
+++ b/ansible/roles/girder/files/girder.conf
@@ -10,6 +10,6 @@ respawn
 respawn limit 20 5
 
 script
-    exec sudo -u hpccloud PYTHONPATH=/opt/hpccloud/cumulus /usr/bin/python -m girder > /dev/null 2>&1
+    exec sudo -u hpccloud /usr/bin/python -m girder > /dev/null 2>&1
 
 end script


### PR DESCRIPTION
To test this either:
1.  Checkout `setuptools-dist` in `cumulus` folder at same level in directory as this repo's checked out folder and run with `DEVELOPMENT=1 vagrant up`
2. Modify the Vagrantfile to include the following patch and run with `vagrant up`

``` patch
@@ -83,7 +83,8 @@ Vagrant.configure(2) do |config|
     ansible.verbose = "vv"
     ansible.extra_vars = {
       default_user: "vagrant",
-      development: dev
+      development: dev,
+      cumulus_version: "setuptools-dist"
     }

     ansible.playbook = "ansible/site.yml"
```
