### PR TITLE
Ansible 2.0 permissions

### DIFF
--- a/ansible/roles/celery/tasks/main.yml
+++ b/ansible/roles/celery/tasks/main.yml
@@ -1,24 +1,24 @@
 - name: Create celery user
   user: name=celery shell=/bin/bash state=present
-  sudo: yes
+  become_user: root
   tags: celery
 
 - name: Add hpccloud user to celery group
   user: name=hpccloud groups=celery append=yes
-  sudo: yes
+  become_user: root
   tags: celery
 
 - name: Download celeryd script
-  sudo: yes
+  become_user: root
   copy: src=../files/init.d/celeryd dest=/etc/init.d/celeryd mode=755 owner=root
   tags: celery
 
 - name: Add celeryd configuration file
-  sudo: yes
+  become_user: root
   copy: src=../files/celeryd dest=/etc/default/celeryd mode=644 owner=root group=root
   tags: celery
 
 - name: Start celery service
-  sudo: yes
+  become_user: root
   service: name=celeryd state=restarted enabled=yes
   tags: celery

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,29 +1,29 @@
 - name: Create application base directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud mode=755 owner=hpccloud group=hpccloud state=directory
   tags:
        - common
 
 - name: Add nodejs ppa
   apt_repository: repo='ppa:chris-lea/node.js' update_cache=no
-  sudo: yes
+  become_user: root
 
 - name: Update apt cache
   apt: update_cache=yes
-  sudo: yes
+  become_user: root
 
 - name: Install Python, git and nodejs
   apt: name={{ item }} state=present
-  sudo: yes
+  become_user: root
   with_items:
     - python-dev
     - git
     - nodejs
 
 - name: Download pip setup
-  sudo: yes
+  become_user: root
   get_url: url=https://bootstrap.pypa.io/get-pip.py dest=.
 
 - name: Install pip
-  sudo: yes
+  become_user: root
   command: python get-pip.py

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -81,6 +81,6 @@
     chdir: /opt/hpccloud/cumulus
     name: .
     extra_args: "-e"
-  sudo: true
+  become_user: root
   when: development
   tags: cumulus

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -5,23 +5,23 @@
 
 - name: Get cumulus from github
   git: repo=https://github.com/Kitware/cumulus.git version={{ cumulus_version }} dest=/opt/hpccloud/cumulus force=yes accept_hostkey=yes
-  sudo: yes
+  become_user: root
   when: path.stat.exists == False
   tags: cumulus
 
 - name: Install cumulus dependencies
   pip: requirements=/opt/hpccloud/cumulus/requirements.txt
-  sudo: yes
+  become_user: root
   tags: cumulus
 
 - name: Create celery user (need to create so we can assign read permission to the cumulus config file)
   user: name=celery shell=/bin/bash state=present
-  sudo: yes
+  become_user: root
   tags: celery
 
 - name: Change owner of cumulus directory
   file: dest=/opt/hpccloud/cumulus mode=775 owner=hpccloud group=celery state=directory recurse=true
-  sudo: yes
+  become_user: root
   tags: cumulus
 
 - name: Tell git to ignore permission changes
@@ -48,7 +48,7 @@
 
 - name: Create keys directory
   file: dest={{ keys_directory }} mode=750 owner=celery group=celery state=directory
-  sudo: yes
+  become_user: root
   tags: cumulus
 
 - name: Get local host name, used in Vagrant deployment
@@ -63,7 +63,7 @@
   tags:
     - cumulus
     - update_ips
-  sudo: yes
+  become_user: root
 
 - name: Install cumulus
   pip:

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -42,6 +42,7 @@
   local_action: command python roles/cumulus/files/ec2_private_ip.py {{ aws_access_key_id }} {{ aws_secret_access_key }} us-west-2 {{ groups['girder'][0] }}
   when: aws_access_key_id != "" and aws_secret_access_key != ""
   register: get_private_ip
+  become: no
   tags:
     - cumulus
     - update_ips
@@ -53,6 +54,7 @@
 
 - name: Get local host name, used in Vagrant deployment
   local_action: command hostname
+  become: no
   register: local_hostname
   tags:
     - cumulus

--- a/ansible/roles/girder/handlers/main.yml
+++ b/ansible/roles/girder/handlers/main.yml
@@ -1,3 +1,3 @@
 - name: restart mongod
   service: name=mongod state=restarted
-  sudo: yes
+  become_user: root

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -1,21 +1,21 @@
 - name: Add nodejs ppa
   apt_repository: repo='ppa:chris-lea/node.js' update_cache=no
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Add MongoDB repo key
   command: apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Add MongoDB repo
   apt_repository: repo='deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' update_cache=yes
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Install package dependencies
   apt: name={{ item }} state=present
-  sudo: yes
+  become_user: root
   tags: girder
   with_items:
     - curl
@@ -27,7 +27,7 @@
 
 - name: Install MongoDb
   apt: name={{ item }} state=present
-  sudo: yes
+  become_user: root
   tags: girder
   with_items:
     - mongodb-org-server
@@ -35,7 +35,7 @@
 
 - name: Enable mongo full-text search
   lineinfile: dest=/etc/mongod.conf regexp=^setParameter= line=setParameter=textSearchEnabled=true
-  sudo: yes
+  become_user: root
   tags: girder
   notify:
     - restart mongod
@@ -45,16 +45,16 @@
   with_items:
     - grunt
     - grunt-cli
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Get Girder from github
   git: repo=https://github.com/girder/girder.git version={{ girder_version }} dest=/opt/hpccloud/girder force=yes accept_hostkey=yes
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Change owner of girder directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/girder mode=755 owner=hpccloud group=hpccloud state=directory recurse=true
   tags: girder
 
@@ -63,14 +63,14 @@
     chdir: /opt/hpccloud/girder
     extra_args: "-e"
     name: .
-  sudo: yes
+  become_user: root
 
 - name: Install editable girder_client
   pip:
     chdir: /opt/hpccloud/girder/clients/python
     extra_args: "-e"
     name: .
-  sudo: yes
+  become_user: root
 
 - name: Generate frontend web assets
   command: "girder-install web"
@@ -85,16 +85,16 @@
 
 - name: Install Girder as service
   copy: src=../files/girder.conf dest=/etc/init/girder.conf mode=644 owner=root
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Start Girder as service
   service: name=girder state=restarted enabled=yes
-  sudo: yes
+  become_user: root
   tags: girder
 
 - name: Copy fixture script
-  sudo: yes
+  become_user: root
   copy: src=../../../../girder/setup.py dest=/tmp/setup.py
   tags:
     - girder

--- a/ansible/roles/hpccloud/handlers/main.yml
+++ b/ansible/roles/hpccloud/handlers/main.yml
@@ -1,3 +1,3 @@
 - name: restart apache2
   service: name=apache2 state=restarted
-  sudo: yes
+  become_user: root

--- a/ansible/roles/hpccloud/tasks/main.yml
+++ b/ansible/roles/hpccloud/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Get hpccloud from github
   git: repo=https://github.com/Kitware/HPCCloud.git version={{ hpccloud_version }} dest=/opt/hpccloud/hpccloud force=yes accept_hostkey=yes
-  sudo: yes
+  become_user: root
   when: path.stat.exists == False
   tags: hpccloud
 
@@ -13,31 +13,31 @@
 - name: Make sure we have the right version of npm
   npm: name=npm version=2.1.5 global=yes
   tags: hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Install n to upgrade node
   npm: name=n global=yes
   tags: hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Install right version of node
   command: n 0.12.0
   tags: hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Install gulp
   npm:  name=gulp global=yes
   tags: hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Install bower
   npm:  name=bower global=yes
   tags: hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Change owner of hpccloud directory
   file: dest=/opt/hpccloud/hpccloud mode=755 owner=hpccloud group=hpccloud state=directory recurse=true
-  sudo: yes
+  become_user: root
   tags: hpccloud
 
 - name: Tell git to ignore permission changes
@@ -58,7 +58,7 @@
 
 - name: Install apache
   apt: name=apache2 state=present
-  sudo: yes
+  become_user: root
   tags:
     - apache
     - hpccloud
@@ -68,21 +68,21 @@
   tags:
     - apache
     - hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Enable mod_rewrite
   apache2_module: state=present name=rewrite
   tags:
     - apache
     - hpccloud
-  sudo: yes
+  become_user: root
 
 - name: Enable mod_proxy_http
   apache2_module: state=present name=proxy_http
   tags:
     - apache
     - hpccloud
-  sudo: yes
+  become_user: root
   notify:
     - restart apache2
 
@@ -91,19 +91,19 @@
   tags:
   - apache
   - hpccloud
-  sudo: yes
+  become_user: root
   notify:
     - restart apache2
 
 - name: Create proxy mapping file
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/proxy.db mode=640 owner=hpccloud group=www-data state=touch
   tags:
     - apache
     - hpccloud
 
 - name: Create local proxy mapping file
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/proxy.txt mode=640 owner=hpccloud group=www-data state=touch
   tags:
     - apache
@@ -113,7 +113,7 @@
   tags:
     - apache
     - hpccloud
-  sudo: yes
+  become_user: root
   notify:
     - restart apache2
 
@@ -121,14 +121,14 @@
 - name: Copy over config
   copy: src=../files/hpccloud.conf dest=/etc/apache2/sites-available/hpccloud.conf mode=644 owner=root
   tags: apache
-  sudo: yes
+  become_user: root
   notify:
     - restart apache2
 
 - name: Enable cmd-web site
   action: command a2ensite hpccloud  creates=/etc/apache2/sites-enabled/hpccloud.conf
   tags: apache
-  sudo: yes
+  become_user: root
   notify:
     - restart apache2
 
@@ -140,6 +140,6 @@
   tags:
     - apache
     - hpccloud
-  sudo: yes
+  become_user: root
   notify:
     - restart apache2

--- a/ansible/roles/moab/tasks/main.yml
+++ b/ansible/roles/moab/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: Create moab directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/moab mode=755 owner=hpccloud group=hpccloud state=directory
   tags: moab
 
 - name: Install moab build prerequisities
-  sudo: yes
+  become_user: root
   apt: name={{ item }} state=present
-  sudo: yes
+  become_user: root
   with_items:
     - cmake
     - cmake-curses-gui
@@ -19,12 +19,12 @@
   tags: moab
 
 - name: Create moab build directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/moab/build mode=755 owner=hpccloud group=hpccloud state=directory
   tags: moab
 
 - name: Create moab install directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/moab/install mode=755 owner=hpccloud group=hpccloud state=directory
   tags: moab
 

--- a/ansible/roles/moabreader/tasks/main.yml
+++ b/ansible/roles/moabreader/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Create moabreader directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/moabreader mode=755 owner=hpccloud group=hpccloud state=directory
   tags: moabreader
 
@@ -8,12 +8,12 @@
   tags: moabreader
 
 - name: Create moabreader build directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/moabreader/build mode=755 owner=hpccloud group=hpccloud state=directory
   tags: moabreader
 
 - name: Create moabreader install directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/moabreader/install mode=755 owner=hpccloud group=hpccloud state=directory
   tags: moabreader
 

--- a/ansible/roles/osmesa/tasks/main.yml
+++ b/ansible/roles/osmesa/tasks/main.yml
@@ -1,16 +1,16 @@
 - name: Add Xorg ppa
   apt_repository: repo='ppa:xorg-edgers/ppa' update_cache=yes
   tags: osmesa
-  sudo: yes
+  become_user: root
 
 - name: Install Mesa build deps
   command: apt-get -y build-dep mesa
-  sudo: yes
+  become_user: root
   tags: osmesa
 
 - name: Install dependencies
   apt: name={{ item }} state=present
-  sudo: yes
+  become_user: root
   with_items:
     - build-essential
     - llvm-dev
@@ -18,7 +18,7 @@
   tags: osmesa
 
 - name: Create OSMesa directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/osmesa mode=755 owner=hpccloud group=hpccloud state=directory
   tags: osmesa
 
@@ -36,5 +36,5 @@
 
 - name: Install Mesa
   command: make install chdir=/opt/hpccloud/osmesa/src
-  sudo: yes
+  become_user: root
   tags: osmesa

--- a/ansible/roles/paraview/tasks/main.yml
+++ b/ansible/roles/paraview/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: Create ParaView directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/paraview mode=755 owner=hpccloud group=hpccloud state=directory
   tags: paraview
 
 - name: Install ParaView build prerequisities
-  sudo: yes
+  become_user: root
   apt: name={{ item }} state=present
-  sudo: yes
+  become_user: root
   with_items:
     - cmake
     - cmake-curses-gui
@@ -19,12 +19,12 @@
   tags: paraview
 
 - name: Create ParaView build directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/paraview/build mode=755 owner=hpccloud group=hpccloud state=directory
   tags: paraview
 
 - name: Create ParaView install directory
-  sudo: yes
+  become_user: root
   file: dest=/opt/hpccloud/paraview/install mode=755 owner=hpccloud group=hpccloud state=directory
   tags: paraview
 

--- a/ansible/roles/pvwlauncher/tasks/main.yml
+++ b/ansible/roles/pvwlauncher/tasks/main.yml
@@ -1,6 +1,5 @@
-
 - name: Template launcher config
-  sudo: yes
+  become_user: root
   action: template src=launcher.json.j2 dest=/etc/default/pvwlauncher mode=644 owner=root
   tags:
     - pvwlauncher
@@ -8,6 +7,5 @@
 
 - name: Install launcher as service
   copy: src=../files/pvwlauncher.conf dest=/etc/init/pvwlauncher.conf mode=644 owner=root
-  sudo: yes
+  become_user: root
   tags: pvwlauncher
-

--- a/ansible/roles/rabbitmq/tasks/main.yml
+++ b/ansible/roles/rabbitmq/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Install rabbitmq
-  sudo: yes
+  become_user: root
   apt: name=rabbitmq-server state=present
   tags: rabbit
 
 - name: Enable rabbitmq-server to survive reboot
   service: name=rabbitmq-server enabled=yes
-  sudo: yes
+  become_user: root
   tags: rabbit

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,54 +1,62 @@
 - name: Create users
   hosts: all
-  user: "{{ default_user }}"
+  become: yes
   roles:
     - users
 
 - name: Common configuration
   hosts: all
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - common
 
 - name: Set up rabbitmq
   hosts: cumulus
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - rabbitmq
 
 - name: Setup cumulus
   hosts: cumulus
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - cumulus
 
 - name: Set up ParaView
   hosts: paraview
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - osmesa
     - paraview
 
 - name: Set up hpccloud
   hosts: hpccloud
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - hpccloud
 
 - name: Setup Girder
   hosts: girder
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - girder
 
 - name: Set up celery
   hosts: cumulus
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - celery
 
 - name: Set up ParaViewWeb launcher
   hosts: pvwlauncher
-  user: hpccloud
+  become: yes
+  become_user: hpccloud
   roles:
     - pvwlauncher


### PR DESCRIPTION
Fixes permissions to use `become` syntax as `sudo` syntax is depricated in 2.0
