### PR TITLE
Running celeryd as hpccloud user

### DIFF
--- a/ansible/roles/celery/files/celeryd
+++ b/ansible/roles/celery/files/celeryd
@@ -28,8 +28,8 @@ CELERYD_PID_FILE="/var/run/celery/%N.pid"
 # Workers should run as an unprivileged user.
 #   You need to create this user manually (or you can choose
 #   a user/group combination that already exists, e.g. nobody).
-CELERYD_USER="celery"
-CELERYD_GROUP="celery"
+CELERYD_USER="hpccloud"
+CELERYD_GROUP="hpccloud"
 
 # If enabled pid and log directories will be created if missing,
 # and owned by the userid/group configured.

--- a/ansible/roles/celery/tasks/main.yml
+++ b/ansible/roles/celery/tasks/main.yml
@@ -1,13 +1,3 @@
-- name: Create celery user
-  user: name=celery shell=/bin/bash state=present
-  become_user: root
-  tags: celery
-
-- name: Add hpccloud user to celery group
-  user: name=hpccloud groups=celery append=yes
-  become_user: root
-  tags: celery
-
 - name: Download celeryd script
   become_user: root
   copy: src=../files/init.d/celeryd dest=/etc/init.d/celeryd mode=755 owner=root

--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -14,13 +14,8 @@
   become_user: root
   tags: cumulus
 
-- name: Create celery user (need to create so we can assign read permission to the cumulus config file)
-  user: name=celery shell=/bin/bash state=present
-  become_user: root
-  tags: celery
-
 - name: Change owner of cumulus directory
-  file: dest=/opt/hpccloud/cumulus mode=775 owner=hpccloud group=celery state=directory recurse=true
+  file: dest=/opt/hpccloud/cumulus mode=775 owner=hpccloud group=hpccloud state=directory recurse=true
   become_user: root
   tags: cumulus
   when: not development
@@ -50,7 +45,7 @@
     - update_ips
 
 - name: Create keys directory
-  file: dest={{ keys_directory }} mode=750 owner=celery group=celery state=directory
+  file: dest={{ keys_directory }} mode=750 owner=hpccloud group=hpccloud state=directory
   become_user: root
   tags: cumulus
 
@@ -63,7 +58,7 @@
     - update_ips
 
 - name: Create config.json
-  action: template src=config.json.j2 dest=/opt/hpccloud/cumulus/cumulus/conf/config.json mode=640 owner=hpccloud group=celery
+  action: template src=config.json.j2 dest=/opt/hpccloud/cumulus/cumulus/conf/config.json mode=640 owner=hpccloud group=hpccloud
   tags:
     - cumulus
     - update_ips

--- a/ansible/roles/girder/tasks/main.yml
+++ b/ansible/roles/girder/tasks/main.yml
@@ -81,7 +81,7 @@
   args:
     chdir: /opt/hpccloud/cumulus/girder/
     creates: /opt/hpccloud/girder/plugins/cumulus
-  tags: grider
+  tags: girder
 
 - name: Install HPCCloud plugins
   shell: "ls | xargs girder-install plugin -s"


### PR DESCRIPTION
For now we need todo this so access to private keys can be shared
between celeryd and Girder.
