### PR TITLE
Add libssl-dev to required packages

### DIFF
--- a/ansible/roles/cumulus/tasks/main.yml
+++ b/ansible/roles/cumulus/tasks/main.yml
@@ -13,6 +13,7 @@
   apt: name="{{ item }}" state=present
   with_items:
     - libffi-dev
+    - libssl-dev
     - openssl
   become: yes
   become_user: root


### PR DESCRIPTION
This is needed when installing ansible 2.1
