### PR TITLE
Upped versions of node and npm to fix provisioning.

### DIFF
--- a/ansible/roles/hpccloud/tasks/main.yml
+++ b/ansible/roles/hpccloud/tasks/main.yml
@@ -21,7 +21,7 @@
   tags: hpccloud
 
 - name: Make sure we have the right version of npm
-  npm: name=npm version=2.1.5 global=yes
+  npm: name=npm version=2.15.9 global=yes
   tags: hpccloud
   become_user: root
 
@@ -31,7 +31,7 @@
   become_user: root
 
 - name: Install right version of node
-  command: n 0.12.9
+  command: n 4.4.5
   tags: hpccloud
   become_user: root
 


### PR DESCRIPTION
Switched node to 4.4.5 and npm to 2.15.9 to fix errors during
ansible provisioning of the vagrant VM.
